### PR TITLE
Expose Shared project internals to unit tests

### DIFF
--- a/ThreeByte.LinkLib/ThreeByte.LinkLib.Shared/ThreeByte.LinkLib.Shared.csproj
+++ b/ThreeByte.LinkLib/ThreeByte.LinkLib.Shared/ThreeByte.LinkLib.Shared.csproj
@@ -6,6 +6,7 @@
     <LangVersion>latest</LangVersion>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
+    <InternalsVisibleTo>ThreeByte.LinkLib.Tests</InternalsVisibleTo>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allows the ThreeByte.LinkLib.Tests project to access internal members for unit testing.
